### PR TITLE
remove pkg_resources from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 Django==1.11.18
-pkg-resources==0.0.0
 pytz==2018.9


### PR DESCRIPTION
I get an error when I try to install it:
```
└[~/brilliant/example_project]> pip install -r requirements.txt
Requirement already satisfied: Django==1.11.18 in ./example_project/lib/python3.7/site-packages (from -r requirements.txt (line 1)) (1.11.18)
Collecting pkg-resources==0.0.0 (from -r requirements.txt (line 2))
  Could not find a version that satisfies the requirement pkg-resources==0.0.0 (from -r requirements.txt (line 2)) (from versions: )
No matching distribution found for pkg-resources==0.0.0 (from -r requirements.txt (line 2))
```
This PR removes that one line from requirements.txt. When I make this change on my working copy, installation succeeds and my django app runs.